### PR TITLE
Fix-e_parallel-input branch to development branch

### DIFF
--- a/cpo_utils.cpp
+++ b/cpo_utils.cpp
@@ -247,17 +247,8 @@ profile cpo_to_profile(const ItmNs::Itm::coreprof &coreprof, const ItmNs::Itm::c
 		// electron temperature
 		celll.electron_temperature = coreprof.te.value(i);
 		
-		// local electric field
-		try{
-			celll.electric_field = coreprof.profiles1d.eparallel.value(i) * coreprof.toroid_field.b0
-					/ interpolate(equilibrium.profiles_1d.rho_tor, equilibrium.profiles_1d.b_av,
-							coreprof.rho_tor(i));
-		
-		// internal error in equilibrium
-		} catch (const std::exception& ex) {
-			celll.electric_field = 0;			
-			std::cerr << "  [Runaway Fluid] ERROR : rho_tor is empty in equilibrium CPO, electric field set to zero. (" << i << ")" << std::endl;
-		}
+		// parallel electric field
+		celll.electric_field = coreprof.profiles1d.eparallel.value(i);
 		
 		try{		
 			// local magnetic field

--- a/ids_utils.cpp
+++ b/ids_utils.cpp
@@ -219,10 +219,8 @@ profile ids_to_profile(const IdsNs::IDS::core_profiles &core_profiles, const Ids
 		// electron temperature
 		celll.electron_temperature = core_profiles.profiles_1d(timeindex).electrons.temperature(i);
 		
-		// local electric field
-		celll.electric_field = core_profiles.profiles_1d(timeindex).e_field.parallel(i) * equilibrium.vacuum_toroidal_field.b0(timeindex)
-				/ interpolate(equilibrium.time_slice(timeindex).profiles_1d.rho_tor, equilibrium.time_slice(timeindex).profiles_1d.b_field_average,
-						core_profiles.profiles_1d(timeindex).grid.rho_tor(i));
+		// parallel electric field
+		celll.electric_field = core_profiles.profiles_1d(timeindex).e_field.parallel(i);
 						
 		// local magnetic field
 		celll.magnetic_field = interpolate(equilibrium.time_slice(timeindex).profiles_1d.rho_tor, equilibrium.time_slice(timeindex).profiles_1d.b_field_average,


### PR DESCRIPTION
The electric field allocation to profiles has been fixed by removing the parallelization to magnetic field (see issue [#35](https://github.com/osrep/Runafluid/issues/35)). The program has been tested on ITM, the merge can be done.